### PR TITLE
Add support for downloading custom SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ or the most recent snapshot/nightly build can be specified with `nightly-6.2`.
 | swift-build-flags | Additional flags to pass to the swift build command |  |
 | swift-test-flags | Additional flags to pass to the swift test command |  |
 | installed-sdk | The name of a pre-installed Swift SDK to use |  |
+| custom-sdk-url | A direct url to a custom SDK that will be downloaded. `custom-sdk-id` and `installed-sdk` must be provided, if this is used. |  |
+| custom-sdk-id | The ID of the custom SDK that will be installed |  |
 | installed-swift | The path to a pre-installed host Swift toolchain |  |
 | test-env | Test environment variables key=value |  |
 | build-package | Whether to build the Swit package | true |

--- a/action.yml
+++ b/action.yml
@@ -103,6 +103,14 @@ inputs:
     required: false
     type: string
     default: ''
+  custom-sdk-url:
+    required: false
+    type: string
+    default: ''
+  custom-sdk-id:
+    required: false
+    type: string
+    default: ''
 
 runs:
   using: "composite"
@@ -320,7 +328,7 @@ runs:
           exit 1
         fi
 
-        if [[ "${{ inputs.installed-sdk }}" != '' ]]; then
+        if [ "${{ inputs.installed-sdk }}" != '' ] && [ "${{ inputs.custom-sdk-url }}" == '']; then
           # we already have an SDK installed
           SWIFT_SDK_TARGET="${{ inputs.installed-sdk }}"
           echo "SWIFT_SDK_TARGET=${SWIFT_SDK_TARGET}" >> $GITHUB_ENV
@@ -330,29 +338,42 @@ runs:
           mkdir -p ${RUNNER_TEMP}/swift-android-toolchain
           cd ${RUNNER_TEMP}/swift-android-toolchain
 
-          SWIFT_SDK_ID="${{ steps.setup.outputs.swift-id }}"
-          # TODO: identify the version automatically
-          SWIFT_SDK_VERSION="0.1"
+          ANDROID_SDK_URL="${{ inputs.custom-sdk-url }}"
           SWIFT_SDK_ARCH="${{ steps.setup.outputs.android-sdk-arch }}"
 
-          # 6.0.x-6.1 (but not 6.1.1)
-          if [[ "${SWIFT_SDK_ID}" =~ "-6.0" || "${SWIFT_SDK_ID}" =~ "-6.1-" ]]; then
-            # Swift Android SDK 6.0/6.1 targets API 24+
-            SWIFT_SDK_ANROID_API="24"
-            SWIFT_SDK_ID="${SWIFT_SDK_ID}-android-${SWIFT_SDK_ANROID_API}-${SWIFT_SDK_VERSION}"
+          if [[ "${ANDROID_SDK_URL}" != '' ]]; then
+            if [ "${{ inputs.installed-sdk }}" == '' ] || [ "${{ inputs.custom-sdk-id }}" == '' ]; then
+              echo "::error::Options 'custom-sdk-id' and 'installed-sdk' must be provided when downloading custom SDK."
+              exit 1
+            fi
+
+            SWIFT_SDK_TARGET="${{ inputs.installed-sdk }}"
+            echo "SWIFT_SDK_TARGET=${SWIFT_SDK_TARGET}" >> $GITHUB_ENV
+            SWIFT_SDK_ID="${{ inputs.custom-sdk-id }}"
           else
-            # Swift Android SDK 6.1.1+ targets API 28+
-            SWIFT_SDK_ANROID_API="28"
-            # 6.2+ no longer includes the API in the artifactbundle name
-            SWIFT_SDK_ID="${SWIFT_SDK_ID}-android-${SWIFT_SDK_VERSION}"
+            # TODO: identify the version automatically
+            SWIFT_SDK_VERSION="0.1"
+            SWIFT_SDK_ID="${{ steps.setup.outputs.swift-id }}"
+
+            # 6.0.x-6.1 (but not 6.1.1)
+            if [[ "${SWIFT_SDK_ID}" =~ "-6.0" || "${SWIFT_SDK_ID}" =~ "-6.1-" ]]; then
+              # Swift Android SDK 6.0/6.1 targets API 24+
+              SWIFT_SDK_ANROID_API="24"
+              SWIFT_SDK_ID="${SWIFT_SDK_ID}-android-${SWIFT_SDK_ANROID_API}-${SWIFT_SDK_VERSION}"
+            else
+              # Swift Android SDK 6.1.1+ targets API 28+
+              SWIFT_SDK_ANROID_API="28"
+              # 6.2+ no longer includes the API in the artifactbundle name
+              SWIFT_SDK_ID="${SWIFT_SDK_ID}-android-${SWIFT_SDK_VERSION}"
+            fi
+            ANDROID_SDK_URL="https://github.com/skiptools/swift-android-toolchain/releases/download/${{ steps.setup.outputs.swift-version }}/${SWIFT_SDK_ID}.artifactbundle.tar.gz"
+
+            SWIFT_SDK_TARGET="${SWIFT_SDK_ARCH}-unknown-linux-android${SWIFT_SDK_ANROID_API}"
+            echo "SWIFT_SDK_TARGET=${SWIFT_SDK_TARGET}" >> $GITHUB_ENV
           fi
-          ANDROID_SDK_URL="https://github.com/skiptools/swift-android-toolchain/releases/download/${{ steps.setup.outputs.swift-version }}/${SWIFT_SDK_ID}.artifactbundle.tar.gz"
 
           echo "ANDROID_SDK_URL: ${ANDROID_SDK_URL}"
           curl -fsSL --retry 8 --retry-connrefused ${ANDROID_SDK_URL} --output ${SWIFT_SDK_ID}.artifactbundle.tar.gz
-
-          SWIFT_SDK_TARGET="${SWIFT_SDK_ARCH}-unknown-linux-android${SWIFT_SDK_ANROID_API}"
-          echo "SWIFT_SDK_TARGET=${SWIFT_SDK_TARGET}" >> $GITHUB_ENV
 
           # first check if it already installed (we may be running this workflow multiple times for an action, in which case it will already be present)
           ${SWIFT_INSTALLATION}/bin/swift sdk configure --show-configuration ${SWIFT_SDK_ID} ${SWIFT_SDK_TARGET} &> /dev/null || ${SWIFT_INSTALLATION}/bin/swift sdk install ${SWIFT_SDK_ID}.artifactbundle.tar.gz

--- a/action.yml
+++ b/action.yml
@@ -114,9 +114,9 @@ runs:
         if [ ${RUNNER_OS} == 'Linux' ]; then
           # enable KVM for hardware accelerated emulators on Linux runners
           # https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | tee /etc/udev/rules.d/99-kvm4all.rules
+          udevadm control --reload-rules
+          udevadm trigger --name-match=kvm
 
           # fetch OS variables like ID ("ubuntu") and VERSION_ID ("24.04")
           . /etc/os-release

--- a/action.yml
+++ b/action.yml
@@ -122,9 +122,9 @@ runs:
         if [ ${RUNNER_OS} == 'Linux' ]; then
           # enable KVM for hardware accelerated emulators on Linux runners
           # https://github.com/ReactiveCircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | tee /etc/udev/rules.d/99-kvm4all.rules
-          udevadm control --reload-rules
-          udevadm trigger --name-match=kvm
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
           # fetch OS variables like ID ("ubuntu") and VERSION_ID ("24.04")
           . /etc/os-release

--- a/action.yml
+++ b/action.yml
@@ -1,108 +1,108 @@
-name: "Swift Android Action"
-description: "Cross-compiles a swift package for Android and runs the test cases in an Android emulator"
+name: 'Swift Android Action'
+description: 'Cross-compiles a swift package for Android and runs the test cases in an Android emulator'
 branding:
-  icon: "target"
-  color: "orange"
+  icon: 'target'
+  color: 'orange'
 outputs:
   swift-build:
-    description: "The swift build command using the installed toolchain and SDK"
+    description: 'The swift build command using the installed toolchain and SDK'
     value: ${{ steps.install.outputs.swiftcmd }}
   swift-sdk:
-    description: "The swift SDK that is used to build for Android"
+    description: 'The swift SDK that is used to build for Android'
     value: ${{ steps.install.outputs.swift-sdk }}
   swift-install:
-    description: "The installation root for the host Swift toolchain"
+    description: 'The installation root for the host Swift toolchain'
     value: ${{ steps.install.outputs.swiftroot }}
 inputs:
   swift-version:
-    description: "The version of the Swift toolchain to use"
+    description: 'The version of the Swift toolchain to use'
     required: true
-    default: "latest"
+    default: 'latest'
   ndk-version:
-    description: "The version of the NDK to use for 6.2+"
+    description: 'The version of the NDK to use for 6.2+'
     required: false
     type: string
-    default: ""
+    default: ''
   swift-branch:
-    description: "The branch of the Swift toolchain to use"
+    description: 'The branch of the Swift toolchain to use'
     required: true
-    default: ""
+    default: ''
   package-path:
-    description: "The folder where the swift package is checked out"
+    description: 'The folder where the swift package is checked out'
     required: true
-    default: "."
+    default: '.'
   swift-build-flags:
-    description: "Additional flags to pass to the swift build command"
+    description: 'Additional flags to pass to the swift build command'
     required: true
-    default: ""
+    default: ''
   swift-configuration:
-    description: "Whether to build in debug or release configuration"
+    description: 'Whether to build in debug or release configuration'
     required: true
-    default: "debug"
+    default: 'debug'
   swift-test-flags:
-    description: "Additional flags to pass to the swift test command"
+    description: 'Additional flags to pass to the swift test command'
     required: true
-    default: ""
+    default: ''
   android-emulator-test-folder:
-    description: "Emulator folder where tests are copied and run"
+    description: 'Emulator folder where tests are copied and run'
     required: true
-    default: "/data/local/tmp/android-xctest"
+    default: '/data/local/tmp/android-xctest'
   test-env:
-    description: "Test environment variables key=value"
+    description: 'Test environment variables key=value'
     required: true
-    default: ""
+    default: ''
   android-emulator-options:
-    description: "Options to pass to the Android emulator"
+    description: 'Options to pass to the Android emulator'
     required: true
-    default: "-no-window -gpu swiftshader_indirect -noaudio -no-boot-anim"
+    default: '-no-window -gpu swiftshader_indirect -noaudio -no-boot-anim'
   android-emulator-boot-timeout:
-    description: "Emulator boot timeout in seconds"
+    description: 'Emulator boot timeout in seconds'
     required: true
     default: 600
   build-package:
-    description: "Whether to build the package or just set up the SDK"
+    description: 'Whether to build the package or just set up the SDK'
     required: true
-    default: "true"
+    default: 'true'
   build-tests:
-    description: "Whether to build the tests or just the sources"
+    description: 'Whether to build the tests or just the sources'
     required: true
-    default: "true"
+    default: 'true'
   run-tests:
-    description: "Whether to run the tests or just the build"
+    description: 'Whether to run the tests or just the build'
     required: true
-    default: "true"
+    default: 'true'
   copy-files:
-    description: "Additional files to copy to emulator for testing"
+    description: 'Additional files to copy to emulator for testing'
     required: true
-    default: ""
+    default: ''
   android-cores:
-    description: "Number of cores to use for the emulator"
+    description: 'Number of cores to use for the emulator'
     required: true
     default: 2
   android-api-level:
-    description: "The API level of the Android emulator to run against"
+    description: 'The API level of the Android emulator to run against'
     required: true
     default: 30
   android-channel:
     required: false
     type: string
-    default: "stable"
+    default: 'stable'
   android-profile:
     required: false
     type: string
-    default: "pixel"
+    default: 'pixel'
   android-target:
     required: false
     type: string
-    default: "aosp_atd"
+    default: 'aosp_atd'
   installed-sdk:
     required: false
     type: string
-    default: ""
+    default: ''
   installed-swift:
     required: false
     type: string
-    default: ""
+    default: ''
 
 runs:
   using: "composite"
@@ -500,7 +500,7 @@ runs:
         path: |
           ~/.android/avd/*
           ~/.android/adb*
-        key: "avd-${{ inputs.android-profile }}_${{ inputs.android-channel }}_${{ inputs.android-target }}_${{ inputs.android-api-level }}-${{ steps.setup.outputs.android-emulator-arch }}"
+        key: 'avd-${{ inputs.android-profile }}_${{ inputs.android-channel }}_${{ inputs.android-target }}_${{ inputs.android-api-level }}-${{ steps.setup.outputs.android-emulator-arch }}'
 
     - name: Create Android Emulator Cache
       if: ${{ inputs.run-tests == 'true' && inputs.build-tests == 'true' && inputs.build-package == 'true' && steps.avd-cache.outputs.cache-hit != 'true' }}
@@ -538,3 +538,4 @@ runs:
         disable-animations: true
         working-directory: ${{ inputs.package-path }}/.build
         script: ./run-android-tests.sh
+

--- a/action.yml
+++ b/action.yml
@@ -328,7 +328,7 @@ runs:
           exit 1
         fi
 
-        if [ "${{ inputs.installed-sdk }}" != '' ] && [ "${{ inputs.custom-sdk-url }}" == '']; then
+        if [[ "${{ inputs.installed-sdk }}" != '' && "${{ inputs.custom-sdk-url }}" == '' ]]; then
           # we already have an SDK installed
           SWIFT_SDK_TARGET="${{ inputs.installed-sdk }}"
           echo "SWIFT_SDK_TARGET=${SWIFT_SDK_TARGET}" >> $GITHUB_ENV
@@ -342,7 +342,7 @@ runs:
           SWIFT_SDK_ARCH="${{ steps.setup.outputs.android-sdk-arch }}"
 
           if [[ "${ANDROID_SDK_URL}" != '' ]]; then
-            if [ "${{ inputs.installed-sdk }}" == '' ] || [ "${{ inputs.custom-sdk-id }}" == '' ]; then
+            if [[ "${{ inputs.installed-sdk }}" == '' || "${{ inputs.custom-sdk-id }}" == '' ]]; then
               echo "::error::Options 'custom-sdk-id' and 'installed-sdk' must be provided when downloading custom SDK."
               exit 1
             fi


### PR DESCRIPTION
Adds a `custom-sdk-url` and `custom-sdk-id` configuration option, to download a custom built SDK instead of either having a pre-installed one or downloading the Skip toolchain one.