### PR TITLE
Add support for specifying specific development snapshots

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -392,6 +392,7 @@ runs:
             SWIFT_SDK_TARGET="${{ inputs.installed-sdk }}"
             echo "SWIFT_SDK_TARGET=${SWIFT_SDK_TARGET}" >> $GITHUB_ENV
             SWIFT_SDK_ID="${{ inputs.custom-sdk-id }}"
+            SWIFT_SDK_ARTIFACT="${SWIFT_SDK_ID}"
           else
             # TODO: identify the version automatically
             SWIFT_SDK_VERSION="0.1"

--- a/action.yml
+++ b/action.yml
@@ -232,6 +232,10 @@ runs:
           # trim the preceeding "swift-" from the beginning, because
           # we add it back in the SWIFT_VERSION_ID
           SWIFT_VERSION="${snapshot_tag//swift-/}"
+        elif [[ "${SWIFT_VERSION}" == *-DEVELOPMENT-SNAPSHOT-* || "${SWIFT_VERSION}" == DEVELOPMENT-SNAPSHOT-* ]]; then
+          # use the exact development snapshot version as-is, without looking it up in the releases file
+          # e.g. "6.3-DEVELOPMENT-SNAPSHOT-2025-12-07-a" or "DEVELOPMENT-SNAPSHOT-2025-12-07-a"
+          log "Using explicit development snapshot: ${SWIFT_VERSION}"
         else
           # match "6.0" to "6.0.3"
           # DO NOT match "6.1" to "6.1-DEVELOPMENT-SNAPSHOT-2025-03-07-a"


### PR DESCRIPTION
Adds support for specifying a Swift version like `6.3-DEVELOPMENT-SNAPSHOT-2025-12-07-a`