### PR TITLE
Add compile-sdk-api-level action input

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -69,3 +69,54 @@ jobs:
           ${{ steps.setup-toolchain.outputs.swift-build }} -c release
           ls -lah .build/release/
 
+  api-levels:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        android-api-level: [23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36]
+    steps:
+      - name: Checkout Action
+        uses: actions/checkout@v6
+        with:
+          path: swift-android-action
+
+      - name: Create Test Package
+        id: create-package
+        shell: bash
+        run: |
+          TEMP_PKG="${RUNNER_TEMP}/ApiTest"
+          rm -rf "${TEMP_PKG}"
+          mkdir -p "${TEMP_PKG}"
+          cd "${TEMP_PKG}"
+          swift package init --type library --name ApiTest
+
+          NEXT_API=$(( ${{ matrix.android-api-level }} + 1 ))
+
+          cat > Tests/ApiTestTests/ApiTestTests.swift << SWIFT_EOF
+          import Testing
+
+          struct ApiTestTests {
+              @available(Android ${{ matrix.android-api-level }}, *)
+              @Test func availableAtTargetAPI() {
+                  #expect(Bool(true))
+              }
+
+              @available(Android ${NEXT_API}, *)
+              @Test func shouldNotRunAtHigherAPI() {
+                  #expect(Bool(false), "Test should not run on Android ${{ matrix.android-api-level }} (requires API ${NEXT_API}+)")
+              }
+          }
+          SWIFT_EOF
+
+          cat Tests/ApiTestTests/ApiTestTests.swift
+
+          echo "package-path=${TEMP_PKG}" >> $GITHUB_OUTPUT
+
+      - name: Test ApiTest with API ${{ matrix.android-api-level }}
+        uses: ./swift-android-action/
+        with:
+          package-path: ${{ steps.create-package.outputs.package-path }}
+          swift-version: nightly-main
+          android-api-level: ${{ matrix.android-api-level }}
+

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -99,7 +99,8 @@ jobs:
           struct ApiTestTests {
               @available(Android ${{ matrix.android-api-level }}, *)
               @Test func availableAtTargetAPI() {
-                  #expect(Bool(true))
+                  // check for https://issuetracker.google.com/issues/36908392
+                  #expect(Bool(false), "Intentional failure")
               }
 
               @available(Android ${NEXT_API}, *)

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -99,8 +99,7 @@ jobs:
           struct ApiTestTests {
               @available(Android ${{ matrix.android-api-level }}, *)
               @Test func availableAtTargetAPI() {
-                  // check for https://issuetracker.google.com/issues/36908392
-                  #expect(Bool(false), "Intentional failure")
+                  #expect(Bool(true))
               }
 
               @available(Android ${NEXT_API}, *)

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36]
+        android-api-level: [23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35]
     steps:
       - name: Checkout Action
         uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ or the most recent snapshot/nightly build can be specified with
 | copy-files | Additional files to copy to emulator for testing | |
 | android-emulator-test-folder | Emulator folder where tests are copied | /data/local/tmp/android-xctest |
 | android-api-level | The API level of the Android emulator to run against | 28 |
+| compile-sdk-api-level | The Android API level for the compile SDK build triple (e.g., setting `23` produces a triple of `x86_64-unknown-linux-android23`). Defaults to the value of `android-api-level`. | |
 | android-channel | SDK component channel: stable, beta, dev, canary | stable |
 | android-profile | Hardware profile used for creating the AVD | pixel |
 | android-target | Target of the system image | aosp_atd |

--- a/action.yml
+++ b/action.yml
@@ -87,6 +87,10 @@ inputs:
     description: 'The API level of the Android emulator to run against'
     required: true
     default: 28
+  compile-sdk-api-level:
+    description: 'The Android API level for the compile SDK build triple (defaults to android-api-level)'
+    required: false
+    default: ''
   android-channel:
     required: false
     type: string
@@ -405,8 +409,13 @@ runs:
             SWIFT_SDK_VERSION="0.1"
             SWIFT_SDK_ID="${{ steps.setup.outputs.swift-id }}"
 
-            # Swift Android SDK 6.1.1+ targets API 28+
-            SWIFT_SDK_ANROID_API="28"
+            # Determine the compile SDK API level (defaults to android-api-level)
+            COMPILE_SDK_API_LEVEL_EXPLICIT="${{ inputs.compile-sdk-api-level }}"
+            if [[ -z "${COMPILE_SDK_API_LEVEL_EXPLICIT}" ]]; then
+              SWIFT_SDK_ANROID_API="${{ inputs.android-api-level }}"
+            else
+              SWIFT_SDK_ANROID_API="${COMPILE_SDK_API_LEVEL_EXPLICIT}"
+            fi
 
             # TODO: get this from the API's "download" property from
             # https://www.swift.org/api/v1/install/dev/main/android-sdk.json
@@ -417,7 +426,10 @@ runs:
             # 6.0.x-6.1 (but not 6.1.1)
             if [[ "${SWIFT_SDK_ID}" =~ "-6.0" || "${SWIFT_SDK_ID}" =~ "-6.1-" ]]; then
               # Swift Android SDK 6.0/6.1 targets API 24+
-              SWIFT_SDK_ANROID_API="24"
+              # only override the API if the user did not explicitly set compile-sdk-api-level
+              if [[ -z "${COMPILE_SDK_API_LEVEL_EXPLICIT}" ]]; then
+                SWIFT_SDK_ANROID_API="24"
+              fi
               SWIFT_SDK_ARTIFACT="${SWIFT_SDK_ID}-android-${SWIFT_SDK_ANROID_API}-${SWIFT_SDK_VERSION}"
               ANDROID_SDK_URL="https://github.com/skiptools/swift-android-toolchain/releases/download/${{ steps.setup.outputs.swift-version }}/${SWIFT_SDK_ARTIFACT}.artifactbundle.tar.gz"
             elif [[ "${SWIFT_SDK_ID}" =~ "-6.1." || "${SWIFT_SDK_ID}" =~ "-6.2" ]]; then


### PR DESCRIPTION
Adds a new input `compile-sdk-api-level` that will permit overriding the compile SDK level (e.g., so you can compile against `x86_64-unknown-linux-android23` but run against an emulator of some other API level).

Also adds validation test cases for every API level from 23-35.