### PR TITLE
Add workaround for tests always reporting as passed on API 23

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -392,6 +392,7 @@ runs:
             SWIFT_SDK_TARGET="${{ inputs.installed-sdk }}"
             echo "SWIFT_SDK_TARGET=${SWIFT_SDK_TARGET}" >> $GITHUB_ENV
             SWIFT_SDK_ID="${{ inputs.custom-sdk-id }}"
+            SWIFT_SDK_ARTIFACT="${SWIFT_SDK_ID}"
           else
             # TODO: identify the version automatically
             SWIFT_SDK_VERSION="0.1"

--- a/action.yml
+++ b/action.yml
@@ -232,6 +232,10 @@ runs:
           # trim the preceeding "swift-" from the beginning, because
           # we add it back in the SWIFT_VERSION_ID
           SWIFT_VERSION="${snapshot_tag//swift-/}"
+        elif [[ "${SWIFT_VERSION}" == *-DEVELOPMENT-SNAPSHOT-* || "${SWIFT_VERSION}" == DEVELOPMENT-SNAPSHOT-* ]]; then
+          # use the exact development snapshot version as-is, without looking it up in the releases file
+          # e.g. "6.3-DEVELOPMENT-SNAPSHOT-2025-12-07-a" or "DEVELOPMENT-SNAPSHOT-2025-12-07-a"
+          log "Using explicit development snapshot: ${SWIFT_VERSION}"
         else
           # match "6.0" to "6.0.3"
           # DO NOT match "6.1" to "6.1-DEVELOPMENT-SNAPSHOT-2025-03-07-a"

--- a/action.yml
+++ b/action.yml
@@ -581,7 +581,9 @@ runs:
             # We additionally need to handle the special exit code EXIT_NO_TESTS_FOUND (69 on Android),
             # which can happen when the tests link to Testing, but no tests are executed
             # see: https://github.com/swiftlang/swift-package-manager/blob/1b593469e8ad3daf2cc10e798340bd2de68c402d/Sources/Commands/SwiftTestCommand.swift#L1542
-            patchelf --print-needed ${XCTEST} | grep libTesting.so && TEST_SHELL="${TEST_SHELL} && ${TEST_CMD} --testing-library swift-testing && [ \$? -eq 0 ] || [ \$? -eq 69 ]" || true
+            # TEMPORARY DIAGNOSTIC: capture the swift-testing run's real exit code into RC and print it,
+            # then apply the same accept-0-or-69 logic as before. Look for "SWIFT_TESTING_RC=" in the run log.
+            patchelf --print-needed ${XCTEST} | grep libTesting.so && TEST_SHELL="${TEST_SHELL} && ${TEST_CMD} --testing-library swift-testing; RC=\$?; echo \"SWIFT_TESTING_RC=\$RC\"; [ \$RC -eq 0 ] || [ \$RC -eq 69 ]" || true
           fi
           echo "adb shell '${TEST_SHELL}'" >> ${SCRIPT_FILE}
         done
@@ -624,7 +626,7 @@ runs:
     - name: Run Tests on Android emulator
       if: ${{ inputs.run-tests == 'true' && inputs.build-tests == 'true' && inputs.build-package == 'true' }}
       uses: reactivecircus/android-emulator-runner@v2
-      with:
+       with:
         force-avd-creation: false
         api-level: ${{ inputs.android-api-level }}
         target: ${{ inputs.android-target }}

--- a/action.yml
+++ b/action.yml
@@ -651,7 +651,7 @@ runs:
     - name: Run Tests on Android emulator
       if: ${{ inputs.run-tests == 'true' && inputs.build-tests == 'true' && inputs.build-package == 'true' }}
       uses: reactivecircus/android-emulator-runner@v2
-       with:
+      with:
         force-avd-creation: false
         api-level: ${{ inputs.android-api-level }}
         target: ${{ inputs.android-target }}

--- a/action.yml
+++ b/action.yml
@@ -604,11 +604,21 @@ runs:
             # We additionally need to handle the special exit code EXIT_NO_TESTS_FOUND (69 on Android),
             # which can happen when the tests link to Testing, but no tests are executed
             # see: https://github.com/swiftlang/swift-package-manager/blob/1b593469e8ad3daf2cc10e798340bd2de68c402d/Sources/Commands/SwiftTestCommand.swift#L1542
-            # TEMPORARY DIAGNOSTIC: capture the swift-testing run's real exit code into RC and print it,
-            # then apply the same accept-0-or-69 logic as before. Look for "SWIFT_TESTING_RC=" in the run log.
-            patchelf --print-needed ${XCTEST} | grep libTesting.so && TEST_SHELL="${TEST_SHELL} && ${TEST_CMD} --testing-library swift-testing; RC=\$?; echo \"SWIFT_TESTING_RC=\$RC\"; [ \$RC -eq 0 ] || [ \$RC -eq 69 ]" || true
+            patchelf --print-needed ${XCTEST} | grep libTesting.so && TEST_SHELL="${TEST_SHELL} && ${TEST_CMD} --testing-library swift-testing && [ \$? -eq 0 ] || [ \$? -eq 69 ]" || true
           fi
-          echo "adb shell '${TEST_SHELL}'" >> ${SCRIPT_FILE}
+          if [ "${{ inputs.android-api-level }}" -le 23 ]; then
+            # On API 23 the exit code from `adb shell` does not get propagated back to the host, so a
+            # failing test run would still pass the job. Instead, write the run's exit code to a file
+            # on the device (TEST_SHELL already collapses to 0 for pass/no-tests, non-zero for
+            # failure), read it back over adb (stdout is forwarded fine), and fail the host script if
+            # it is not 0.
+            REMOTE_RC_FILE="${REMOTE_FOLDER}/${TEST_BASE_FOLDER}/xctest-exit-code"
+            echo "adb shell '${TEST_SHELL}; echo \$? > ${REMOTE_RC_FILE}'" >> ${SCRIPT_FILE}
+            echo "RC=\$(adb shell cat ${REMOTE_RC_FILE} | tr -d '\\r')" >> ${SCRIPT_FILE}
+            echo "[ \"\$RC\" = 0 ] || { echo \"::error::Android tests failed (exit \$RC)\"; exit 1; }" >> ${SCRIPT_FILE}
+          else
+            echo "adb shell '${TEST_SHELL}'" >> ${SCRIPT_FILE}
+          fi
         done
 
         # ensure the emulator stops when we are done


### PR DESCRIPTION
Fixes #25 